### PR TITLE
Fixing syntax errors in a number of searches 

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -1106,7 +1106,7 @@ request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
 search = `sysmon` event_id=3 (process_name="reg.exe" AND process_command_line="*reg* query*") \
 | eval mitre_technique_id="T1012" \
-| 'network_whitelist`\
+| `network_whitelist`\
 | table _time event_description host_fqdn user_name process_path process_id process_parent_id process_command_line process_guid src_ip dst_ip dst_port src_host_name dst_host_name
 
 [[T1012] Query Registry - Process]
@@ -1142,7 +1142,7 @@ cron_schedule = */15 * * * *
 dispatch.earliest_time = -15m@m
 dispatch.latest_time = now
 enableSched = 1
-search = `sysmon` event_id=20 wmi_consumer_type="Command Line"
+search = `sysmon` event_id=20 wmi_consumer_type="Command Line" \
 | eval mitre_technique_id = "T1047" \
 | eval hash_sha256= lower(hash_sha256)\
 | `wmi_whitelist`\
@@ -1479,9 +1479,9 @@ enableSched = 1
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
 search = `sysmon` event_id=1 process_command_line="*Invoke-Mimikatz -DumpCreds*" OR process_command_line="gsecdump* -a" OR process_command_line="wce* -o" OR process_command_line="procdump* -ma lsass.exe*" OR process_command_line="ntdsutil*ac i ntds*ifm*create full"\
-| eval mitre_technique_id="T1003" \ \
-| eval hash_sha256= lower(hash_sha256)\ \
-| `process_create_whitelist`\ \
+| eval mitre_technique_id="T1003" \
+| eval hash_sha256= lower(hash_sha256)\
+| `process_create_whitelist`\
 | table _time event_description hash_sha256 host_fqdn user_name process_path process_guid process_parent_path process_id process_parent_id process_command_line process_parent_command_line process_parent_guid
 
 [[T1007] System Service Discovery]
@@ -1554,7 +1554,7 @@ dispatch.latest_time = now
 enableSched = 1
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
-search = `sysmon` event_id=1 (process_name="net.exe" OR process_name="netstat.exe") AND (process_command_line="*net* use*" OR process_command_line="*net* sessions*" OR process_command_line="*net* file*" OR process_command_line="*netstat*") OR OR process_command_line="*Get-NetTCPConnection*"\
+search = `sysmon` event_id=1 (process_name="net.exe" OR process_name="netstat.exe") AND (process_command_line="*net* use*" OR process_command_line="*net* sessions*" OR process_command_line="*net* file*" OR process_command_line="*netstat*") OR process_command_line="*Get-NetTCPConnection*"\
 | eval mitre_technique_id="T1049" \
 | eval hash_sha256= lower(hash_sha256)\
 | `process_create_whitelist`\
@@ -1711,7 +1711,7 @@ dispatch.latest_time = now
 enableSched = 1
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
-search = `sysmon` event_id=1 (process_name="sysinfo.exe") OR (process_name="reg.exe" AND process_command_line="reg*query HKLM\\SYSTEM\\CurrentControlSet\\Services\\Disk\\Enum"\
+search = `sysmon` event_id=1 (process_name="sysinfo.exe") OR (process_name="reg.exe" AND process_command_line="reg*query HKLM\\SYSTEM\\CurrentControlSet\\Services\\Disk\\Enum")\
 | eval mitre_technique_id="T1082" \
 | eval hash_sha256= lower(hash_sha256)\
 | `process_create_whitelist`\
@@ -1872,7 +1872,7 @@ dispatch.latest_time = now
 enableSched = 1
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
-search = `sysmon` event_id=1 (process_name="netsh.exe" AND process_command_line="*helper*"\
+search = `sysmon` event_id=1 (process_name="netsh.exe" AND process_command_line="*helper*")\
 | eval mitre_technique_id="T1128" \
 | eval hash_sha256= lower(hash_sha256)\
 | `process_create_whitelist`\
@@ -1952,9 +1952,9 @@ enableSched = 1
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
 search = `sysmon` event_id=1 (process_command_line="*Get-History*" OR process_command_line="*AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadline\\ConsoleHost_history.txt*" OR process_command_line="*(Get-PSReadlineOption).HistorySavePath*") \
-| eval mitre_technique_id="T0000" \ \
-| eval hash_sha256= lower(hash_sha256)\ \
-| `process_create_whitelist`\ \
+| eval mitre_technique_id="T0000" \
+| eval hash_sha256= lower(hash_sha256)\
+| `process_create_whitelist`\
 | table _time event_description hash_sha256 host_fqdn user_name process_path process_guid process_parent_path process_id process_parent_id process_command_line process_parent_command_line process_parent_guid
 
 [[T1140] Deobfuscate/Decode Files or Information]
@@ -2008,9 +2008,9 @@ enableSched = 1
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
 search = `sysmon` event_id=1 (process_command_line="*rm (Get-PSReadlineOption).HistorySavePath*" OR process_command_line="*del (Get-PSReadlineOption).HistorySavePath*" OR process_command_line="*Set-PSReadlineOption –HistorySaveStyle SaveNothing*" OR process_command_line="*Remove-Item (Get-PSReadlineOption).HistorySavePath*") \
-| eval mitre_technique_id="T1146" \ \
-| eval hash_sha256= lower(hash_sha256)\ \
-| `process_create_whitelist`\ \
+| eval mitre_technique_id="T1146" \
+| eval hash_sha256= lower(hash_sha256) \
+| `process_create_whitelist` \
 | table _time event_description hash_sha256 host_fqdn user_name process_path process_guid process_parent_path process_id process_parent_id process_command_line process_parent_command_line process_parent_guid
 
 [[T1158] Hidden Files and Directories]
@@ -2100,7 +2100,7 @@ dispatch.latest_time = now
 enableSched = 1
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
-search = `sysmon` event_id=1 (process_parent_name="pcalua.exe" OR process_name="pcalua.exe" OR process_name="bash.exe" OR process_name="forfiles.exe"\
+search = `sysmon` event_id=1 (process_parent_name="pcalua.exe" OR process_name="pcalua.exe" OR process_name="bash.exe" OR process_name="forfiles.exe")\
 | eval mitre_technique_id="T1202" \
 | eval hash_sha256= lower(hash_sha256)\
 | `process_create_whitelist`\


### PR DESCRIPTION
This fixes several small syntax errors in Splunk searches (missing perens, unmatched quotes, extra backslashes, missing backslashes)