### PR TITLE
Update to WMI Whitelist Macro

### DIFF
--- a/default/macros.conf
+++ b/default/macros.conf
@@ -75,7 +75,7 @@ definition = lookup pipe_whitelist mitre_technique_id host_fqdn process_path pip
 iseval = 0
 
 [wmi_whitelist]
-definition = lookup wmi_whitelist mitre_technique_id host_fqdn process_path pipe_name output reason |  where isnull(reason)
+definition = lookup wmi_whitelist mitre_technique_id host_fqdn process_path wmi_consumer_name wmi_consumer_destination output reason |  where isnull(reason)
 iseval = 0
 
 [dns_whitelist]

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -75,7 +75,7 @@ definition = lookup pipe_whitelist mitre_technique_id host_fqdn process_path pip
 iseval = 0
 
 [wmi_whitelist]
-definition = lookup wmi_whitelist mitre_technique_id host_fqdn process_path wmi_consumer_name wmi_consumer_destination output reason |  where isnull(reason)
+definition = lookup wmi_whitelist mitre_technique_id host_fqdn user_name wmi_consumer_name wmi_consumer_destination output reason |  where isnull(reason)
 iseval = 0
 
 [dns_whitelist]


### PR DESCRIPTION
I updated the WMI Whitelist macro to reflect the field names for the Whitelist. It listed `process_path pipe_name` (appears to have been a copy of the `pipe_whitelist` verbiage. These were removed and replaced with `user_name wmi_consumer_name wmi_consumer_destination` which should match the fields reflected in the WMI Whitelist view.