### PR TITLE
added missing character in saved search

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -2697,7 +2697,7 @@ search = `indextime` `sysmon` event_id=3 (dest_port=389 OR dest_port=636 OR dest
 | `network_whitelist`\
 | eval indextime = _indextime | convert ctime(indextime) | table _time indextime event_description host_fqdn user_name process_path process_id process_parent_id process_command_line process_guid src_ip dst_ip dst_port src_host_name dst_host_name
 
-[T1044] File System Permissions Weakness]
+[[T1044] File System Permissions Weakness]
 action.email.useNSSubject = 1
 action.summary_index = 1
 action.summary_index._name = threathunting


### PR DESCRIPTION
Cosmetic fix of missing `[` character within `savedsearches.conf`.