### PR TITLE
Update savedsearches.conf to address Issue #61 - missing double quote

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -1101,7 +1101,7 @@ enableSched = 1
 schedule_window = auto
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
-search = `indextime` `sysmon` (event_id=12 OR event_id=13 OR event_id=14) process_path!="C:\\WINDOWS\\system32\\lsass.exe"  (registry_key_path="*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SecurityProviders\\*" OR registry_key_path="*\\Control\\SecurityProviders\\WDigest\\*") NOT registry_key_path="*\\Lsa\\RestrictRemoteSamEventThrottlingWindow NOT registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\nolmhash" \
+search = `indextime` `sysmon` (event_id=12 OR event_id=13 OR event_id=14) process_path!="C:\\WINDOWS\\system32\\lsass.exe"  (registry_key_path="*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SecurityProviders\\*" OR registry_key_path="*\\Control\\SecurityProviders\\WDigest\\*") NOT registry_key_path="*\\Lsa\\RestrictRemoteSamEventThrottlingWindow" NOT registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\nolmhash" \
 | eval mitre_technique_id="T1003" \
 | `registry_whitelist`\
 | eval indextime = _indextime | convert ctime(indextime) | table _time indextime event_description event_type host_fqdn process_path  process_id process_guid registry_key_path registry_key_details


### PR DESCRIPTION
Added missing double-quote - The search misses a quote after RestrictedRemoteSamEventThrottelingWindow before the NOT.