### PR TITLE
Eval command failing in props.conf #60 - Updated

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -1,6 +1,6 @@
 #OSSEM compatibility https://github.com/Cyb3rWard0g/OSSEM
 
-[XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
+[source::XmlWinEventLog:Microsoft-Windows-Sysmon/Operational]
 EVAL-process_id = case(EventCode=="1" OR EventCode=="2" OR EventCode=="3" OR EventCode=="5" OR EventCode=="7" OR EventCode=="9" OR EventCode=="11" OR EventCode=="12" OR EventCode=="13" OR EventCode=="14" OR EventCode=="15" OR EventCode=="17" OR EventCode=="18" OR EventCode=="22", ProcessId,EventCode=="6","System",EventCode=="8" OR EventCode=="10",SourceProcessId)
 EVAL-process_guid = case(EventCode=="1" OR EventCode=="2" OR EventCode=="3" OR EventCode=="5" OR EventCode=="7" OR EventCode=="9" OR EventCode=="11" OR EventCode=="12" OR EventCode=="13" OR EventCode=="14" OR EventCode=="15" OR EventCode=="17" OR EventCode=="18" OR EventCode=="22", ProcessGuid,EventCode=="6","System",EventCode=="8" OR EventCode=="10",SourceProcessGuid)
 EVAL-process_name = case(EventCode=="1" OR EventCode=="2" OR EventCode=="3" OR EventCode=="5" OR EventCode=="7" OR EventCode=="9" OR EventCode=="11" OR EventCode=="12" OR EventCode=="13" OR EventCode=="14" OR EventCode=="15" OR EventCode=="17" OR EventCode=="18" OR EventCode=="22", replace(Image,"(.*\\\)(?=.*(\.\w*)$|(\w+)$)",""),EventCode=="6","System",EventCode=="8" OR EventCode=="10",replace(SourceImage,"(.*\\\)(?=.*(\.\w*)$|(\w+)$)",""),1==1,"")


### PR DESCRIPTION
Updated [XmlWinEventLog:Microsoft-Windows-Sysmon/Operational] to [source::XmlWinEventLog:Microsoft-Windows-Sysmon/Operational] to allow the proper setting of event_id = EventCode