### PR TITLE
Missing definitions in ./default/props.conf #55

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -26,6 +26,7 @@ EVAL-event_type = EventType
 EVAL-event_creation_time = UtcTime
 LOOKUP-sysmoneventcodes = sysmoneventcodes.csv EventCode OUTPUTNEW event_description
 
+EVAL-file_name = coalesce(file_name,OriginalFileName)
 EVAL-file_path = TargetFilename
 EVAL-file_extension =
 EVAL-file_version = FileVersion

--- a/default/props.conf
+++ b/default/props.conf
@@ -129,7 +129,7 @@ EVAL-event_type = EventType
 EVAL-event_creation_time = UtcTime
 LOOKUP-sysmoneventcodes = sysmoneventcodes.csv EventCode OUTPUTNEW event_description
 
-
+EVAL-file_name = coalesce(file_name,OriginalFileName)
 EVAL-file_path = TargetFilename
 EVAL-file_extension =
 EVAL-file_version = FileVersion


### PR DESCRIPTION
This is because there is TargetFileName populationg file_nasme from the sysmon app and the original_file_naame being populated by OriginalFileName from this app. I added EVAL-file_name = coalesce(file_name,OriginalFileName) to the props to handle consolidating the file names into a common field