### PR TITLE
whitelist dashboard updates

### DIFF
--- a/default/app.conf
+++ b/default/app.conf
@@ -14,4 +14,4 @@ label = ThreatHunting
 [launcher]
 author = Olaf Hartong
 description = A Splunk app mapped to MITRE ATT&CK to guide your threat hunts
-version = 1.4.3
+version = 1.4.4

--- a/default/data/ui/views/dns_whitelist.xml
+++ b/default/data/ui/views/dns_whitelist.xml
@@ -17,29 +17,44 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval query_name = COALESCE(if(trim("$query_name$")="", "*", trim("$query_name$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_query_name = COALESCE(if(trim("$query_name$")="", "*", trim("$query_name$")), "*") 
 
-    | fields - _raw _time
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_dns_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval process_path = input_process_path 
+| eval query_name = input_query_name 
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup host_fqdn process_path query_name
-| outputlookup threathunting_dns_whitelist.csv
-| fields added_date contact reason host_fqdn process_path query_name
-          </query>
+| inputlookup append=t threathunting_dns_whitelist.csv 
+| sort -added_date 
+| dedup host_fqdn process_path query_name 
+
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and host_fqdn=input_host_fqdn and process_path=input_process_path and query_name=input_query_name, "yes", "no") 
+| where delete="no" 
+| fields - delete mode 
+
+| outputlookup threathunting_dns_whitelist.csv 
+| fields added_date contact reason host_fqdn process_path query_name</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/file_access_whitelist.xml
+++ b/default/data/ui/views/file_access_whitelist.xml
@@ -32,31 +32,46 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval file_path = COALESCE(if(trim("$file_path$")="", "*", trim("$file_path$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_file_path = COALESCE(if(trim("$file_path$")="", "*", trim("$file_path$")), "*") 
 
-    | fields - _raw _time
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_file_access_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval file_path = input_file_path 
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn process_path file_path
-| outputlookup threathunting_file_access_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn process_path file_path
+| inputlookup append=t threathunting_file_access_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn process_path file_path 
 
-          </query>
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and process_path=input_process_path and file_path=input_file_path, "yes", "no") 
+| where delete="no" 
+| fields - delete mode
+
+| outputlookup threathunting_file_access_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn process_path file_path</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/file_create_whitelist.xml
+++ b/default/data/ui/views/file_create_whitelist.xml
@@ -36,32 +36,47 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval file_name = COALESCE(if(trim("$file_path$")="", "*", trim("$file_name$")), "*")
-    | eval file_path = COALESCE(if(trim("$file_path$")="", "*", trim("$file_path$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | table *
+          <query>| makeresults 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_file_name = COALESCE(if(trim("$file_name$")="", "*", trim("$file_name$")), "*") 
+| eval input_file_path = COALESCE(if(trim("$file_path$")="", "*", trim("$file_path$")), "*") 
 
-    | fields - _raw _time
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_file_create_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval file_name = input_file_name
+| eval file_path = input_file_path 
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$")
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn process_path file_path file_name
-| outputlookup threathunting_file_create_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn process_path file_path file_name
+| inputlookup append=t threathunting_file_create_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn process_path file_path file_name 
 
-          </query>
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and process_path=input_process_path and file_name=input_file_name and file_path=input_file_path, "yes", "no") 
+| where delete="no" 
+| fields - delete mode 
+
+| outputlookup threathunting_file_create_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn process_path file_path file_name</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/image_load_whitelist.xml
+++ b/default/data/ui/views/image_load_whitelist.xml
@@ -44,35 +44,52 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval driver_loaded = COALESCE(if(trim("$driver_loaded$")="", "*", trim("$driver_loaded$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval driver_is_signed = COALESCE(if(trim("$driver_is_signed$")="", "*", trim("$driver_is_signed$")), "*")
-    | eval driver_signature = COALESCE(if(trim("$driver_signature$")="", "*", trim("$driver_signature$")), "*")
-    | eval driver_signature_status = COALESCE(if(trim("$driver_signature_status$")="", "*", trim("$driver_signature_status$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | eval contact = ("$env:user$")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_driver_loaded = COALESCE(if(trim("$driver_loaded$")="", "*", trim("$driver_loaded$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_driver_is_signed = COALESCE(if(trim("$driver_is_signed$")="", "*", trim("$driver_is_signed$")), "*") 
+| eval input_driver_signature = COALESCE(if(trim("$driver_signature$")="", "*", trim("$driver_signature$")), "*") 
+| eval input_driver_signature_status = COALESCE(if(trim("$driver_signature_status$")="", "*", trim("$driver_signature_status$")), "*") 
 
-    | fields - _raw _time 
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_image_load_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval driver_loaded = input_driver_loaded 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval driver_is_signed = input_driver_is_signed 
+| eval driver_signature = input_driver_signature 
+| eval driver_signature_status = input_driver_signature_status 
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn process_path driver_loaded driver_is_signed driver_signature driver_signature_status
-| outputlookup threathunting_image_load_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn process_path driver_loaded driver_is_signed driver_signature driver_signature_status
+| inputlookup append=t threathunting_image_load_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn process_path driver_loaded driver_is_signed driver_signature driver_signature_status 
 
-          </query>
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and driver_loaded=input_driver_loaded and process_path=input_process_path and driver_is_signed=input_driver_is_signed and driver_signature=input_driver_signature and driver_signature_status=input_driver_signature_status, "yes", "no") 
+| where delete="no" 
+| fields - delete mode 
+
+| outputlookup threathunting_image_load_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn process_path driver_loaded driver_is_signed driver_signature driver_signature_status</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/network_whitelist.xml
+++ b/default/data/ui/views/network_whitelist.xml
@@ -44,35 +44,52 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Recent Entries</title>
         <search>
-          <query>
-    | makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval user_name = COALESCE(if(trim("$user_name$")="", "*", trim("$user_name$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")     
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval src_ip = COALESCE(if(trim("$src_ip$")="", "*", trim("$src_ip$")), "*")
-    | eval dst_ip = COALESCE(if(trim("$dst_ip$")="", "*", trim("$dst_ip$")), "*") 
-    | eval dst_port = COALESCE(if(trim("$dst_port$")="", "*", trim("$dst_port$")), "*") 
-    | eval contact = ("$env:user$")
-    | eval added_date = strftime(now(), "%Y-%m-%d")     
-    | table *
-    | fields - _raw _time count
-    | where NOT (reason="CHANGEME")
-| inputlookup append=t threathunting_network_whitelist.csv
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_user_name = COALESCE(if(trim("$user_name$")="", "*", trim("$user_name$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_src_ip = COALESCE(if(trim("$src_ip$")="", "*", trim("$src_ip$")), "*") 
+| eval input_dst_ip = COALESCE(if(trim("$dst_ip$")="", "*", trim("$dst_ip$")), "*") 
+| eval input_dst_port = COALESCE(if(trim("$dst_port$")="", "*", trim("$dst_port$")), "*") 
 
-| dedup host_fqdn, user_name, mitre_technique_id, process_path src_ip dst_ip dst_port
+| eval host_fqdn = input_host_fqdn 
+| eval user_name = input_user_name 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval src_ip = input_src_ip 
+| eval dst_ip = input_dst_ip 
+| eval dst_port = input_dst_port 
+| eval reason = trim("$input_reason$") 
+| eval contact = ("$env:user$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| table * 
+| fields - _raw _time count 
+| where NOT (reason="CHANGEME") 
+
+| inputlookup append=t threathunting_network_whitelist.csv 
 | sort -added_date
-| outputlookup threathunting_network_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn user_name process_path src_ip dst_ip dst_port 
-          
-          </query>
+| dedup host_fqdn, user_name, mitre_technique_id, process_path src_ip dst_ip dst_port 
+ 
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and user_name=input_user_name and process_path=input_process_path and src_ip=input_src_ip and dst_ip=input_dst_ip and dst_port=input_dst_port, "yes", "no") 
+| where delete="no" 
+| fields - delete mode  
+
+| outputlookup threathunting_network_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn user_name process_path src_ip dst_ip dst_port</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/pipe_whitelist.xml
+++ b/default/data/ui/views/pipe_whitelist.xml
@@ -32,32 +32,46 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval pipe_name = COALESCE(if(trim("$pipe_name$")="", "*", trim("$pipe_name$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | eval contact = ("$env:user$")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_pipe_name = COALESCE(if(trim("$pipe_name$")="", "*", trim("$pipe_name$")), "*") 
 
-    | fields - _raw _time 
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_pipe_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval pipe_name = input_pipe_name 
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn process_path pipe_name
-| outputlookup threathunting_pipe_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn process_path pipe_name
+| inputlookup append=t threathunting_pipe_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn process_path pipe_name 
 
-          </query>
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and process_path=input_process_path and pipe_name=input_pipe_name, "yes", "no") 
+| where delete="no" 
+| fields - delete mode
+
+| outputlookup threathunting_pipe_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn process_path pipe_name</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/process_access_whitelist.xml
+++ b/default/data/ui/views/process_access_whitelist.xml
@@ -36,32 +36,48 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query> | makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval process_granted_access = COALESCE(if(trim("$process_granted_access$")="", "*", trim("$process_granted_access$")), "*")
-    | eval target_process_path = COALESCE(if(trim("$target_process_path$")="", "*", trim("$target_process_path$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | eval contact = ("$env:user$")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_process_granted_access = COALESCE(if(trim("$process_granted_access$")="", "*", trim("$process_granted_access$")), "*") 
+| eval input_target_process_path = COALESCE(if(trim("$target_process_path$")="", "*", trim("$target_process_path$")), "*") 
 
-    | fields - _raw _time 
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_process_access_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval process_granted_access = input_process_granted_access 
+| eval target_process_path = input_target_process_path 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval reason = trim("$input_reason$") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn process_path target_process_path process_granted_access
-| outputlookup threathunting_process_access_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn process_path target_process_path process_granted_access
-          </query>
+| inputlookup append=t threathunting_process_access_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn process_path target_process_path process_granted_access 
+
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and process_path=input_process_path and process_granted_access=input_process_granted_access and target_process_path=input_target_process_path, "yes", "no") 
+| where delete="no" 
+| fields - delete mode 
+
+| outputlookup threathunting_process_access_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn process_path target_process_path process_granted_access</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/process_create_whitelist.xml
+++ b/default/data/ui/views/process_create_whitelist.xml
@@ -45,34 +45,52 @@
       <label>Reason</label>
       <default>CHANGEME</default>
     </input>
+        <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Recent Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval user_name = COALESCE(if(trim("$user_name$")="", "*", trim("$user_name$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_command_line = $process_command_line|s$
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval process_parent_path = COALESCE(if(trim("$process_parent_path$")="", "*", trim("$process_parent_path$")), "*")
-    | eval hash_sha256 = COALESCE(if(trim("$hash_sha256$")="", "*", trim("$hash_sha256$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | eval contact = ("$env:user$")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_user_name = COALESCE(if(trim("$user_name$")="", "*", trim("$user_name$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_command_line = $process_command_line COALESCE(if(trim("$process_command_line$")="", "*", trim("$process_command_line$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_process_parent_path = COALESCE(if(trim("$process_parent_path$")="", "*", trim("$process_parent_path$")), "*") 
+| eval input_hash_sha256 = COALESCE(if(trim("$hash_sha256$")="", "*", trim("$hash_sha256$")), "*") 
 
-    | fields - _raw _time 
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_process_create_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval user_name = input_user_name 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_command_line = input_process_command_line
+| eval process_path = input_process_path 
+| eval process_parent_path = input_process_parent_path 
+| eval hash_sha256 = input_hash_sha256 
+| eval reason = trim("$input_reason$")
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup host_fqdn, user_name, mitre_technique_id, process_path process_parent_path process_command_line hash_sha256
-| outputlookup threathunting_process_create_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn user_name process_path process_parent_path process_command_line hash_sha256
-          </query>
+| inputlookup append=t threathunting_process_create_whitelist.csv 
+| sort -added_date 
+| dedup host_fqdn, user_name, mitre_technique_id, process_path process_parent_path process_command_line hash_sha256 
+
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and user_name=input_user_name and process_command_line=input_process_command_line and process_path=input_process_path and process_parent_path=input_process_parent_path and hash_sha256=input_hash_sha256, "yes", "no") 
+| where delete="no" 
+| fields - delete mode 
+
+| outputlookup threathunting_process_create_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn user_name process_path process_parent_path process_command_line hash_sha256</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/registry_whitelist.xml
+++ b/default/data/ui/views/registry_whitelist.xml
@@ -40,33 +40,50 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval event_type = COALESCE(if(trim("$event_type$")="", "*", trim("$event_type$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval registry_key_path = COALESCE(if(trim("$registry_key_path$")="", "*", trim("$registry_key_path$")), "*")
-    | eval registry_key_details = COALESCE(if(trim("$registry_key_details$")="", "*", trim("$registry_key_details$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | eval contact = ("$env:user$")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_event_type = COALESCE(if(trim("$event_type$")="", "*", trim("$event_type$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_registry_key_path = COALESCE(if(trim("$registry_key_path$")="", "*", trim("$registry_key_path$")), "*") 
+| eval input_registry_key_details = COALESCE(if(trim("$registry_key_details$")="", "*", trim("$registry_key_details$")), "*") 
 
-    | fields - _raw _time
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_registry_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval event_type = input_event_type 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval registry_key_path = input_registry_key_path 
+| eval registry_key_details = input_registry_key_details
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn event_type process_path registry_key_path registry_key_details
-| outputlookup threathunting_registry_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn event_type process_path registry_key_path registry_key_details
-          </query>
+| inputlookup append=t threathunting_registry_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn event_type process_path registry_key_path registry_key_details 
+
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and event_type=input_event_type and process_path=input_process_path and registry_key_path=input_registry_key_path and registry_key_details=input_registry_key_details, "yes", "no") 
+| where delete="no" 
+| fields - delete mode 
+
+| outputlookup threathunting_registry_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn event_type process_path registry_key_path registry_key_details</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/remote_thread_whitelist.xml
+++ b/default/data/ui/views/remote_thread_whitelist.xml
@@ -40,33 +40,50 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval event_type = COALESCE(if(trim("$event_type$")="", "*", trim("$event_type$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*")
-    | eval target_process_path = COALESCE(if(trim("$target_process_path$")="", "*", trim("$target_process_path$")), "*")
-    | eval target_process_address = COALESCE(if(trim("$target_process_address$")="", "*", trim("$target_process_address$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | eval contact = ("$env:user$")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_event_type = COALESCE(if(trim("$event_type$")="", "*", trim("$event_type$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_process_path = COALESCE(if(trim("$process_path$")="", "*", trim("$process_path$")), "*") 
+| eval input_target_process_path = COALESCE(if(trim("$target_process_path$")="", "*", trim("$target_process_path$")), "*") 
+| eval input_target_process_address = COALESCE(if(trim("$target_process_address$")="", "*", trim("$target_process_address$")), "*") 
 
-    | fields - _raw _time
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_remote_thread_whitelist.csv
+| eval host_fqdn = input_host_fqdn 
+| eval event_type = input_event_type 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval process_path = input_process_path 
+| eval target_process_path = input_target_process_path 
+| eval target_process_address = input_target_process_address 
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn event_type process_path target_process_path target_process_address
-| outputlookup threathunting_remote_thread_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn event_type process_path target_process_path target_process_address
-          </query>
+| inputlookup append=t threathunting_remote_thread_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn event_type process_path target_process_path target_process_address 
+
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and event_type=input_event_type and process_path=input_process_path and target_process_path=input_target_process_path and target_process_address=input_target_process_address, "yes", "no") 
+| where delete="no" 
+| fields - delete mode
+
+| outputlookup threathunting_remote_thread_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn event_type process_path target_process_path target_process_address</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>

--- a/default/data/ui/views/wmi_whitelist.xml
+++ b/default/data/ui/views/wmi_whitelist.xml
@@ -36,33 +36,48 @@
       <label>reason</label>
       <default>CHANGEME</default>
     </input>
+    <input type="radio" token="input_mode">
+      <label>Mode</label>
+      <choice value="add">Add</choice>
+      <choice value="delete">Remove</choice>
+      <default>add</default>
+    </input>
   </fieldset>
   <row>
     <panel>
       <table>
         <title>Today's Entries</title>
         <search>
-          <query>| makeresults
-    | eval host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*")
-    | eval mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*")
-    | eval reason = trim("$input_reason$")
-    | eval wmi_consumer_name = COALESCE(if(trim("$wmi_consumer_name$")="", "*", trim("$wmi_consumer_name$")), "*")
-    | eval wmi_consumer_destination = COALESCE(if(trim("$wmi_consumer_destination$")="", "*", trim("$wmi_consumer_destination$")), "*")    
-    | eval user_name = COALESCE(if(trim("$user_name$")="", "*", trim("$user_name$")), "*")
-    | eval added_date = strftime(now(), "%Y-%m-%d")
-    | eval contact = ("$env:user$")
-    | table *
+          <query>| makeresults 
+| eval input_host_fqdn = COALESCE(if(trim("$host_fqdn$")="", "*", trim("$host_fqdn$")), "*") 
+| eval input_mitre_technique_id = COALESCE(if(trim("$mitre_technique_id$")="", "*", trim("$mitre_technique_id$")), "*") 
+| eval input_wmi_consumer_name = COALESCE(if(trim("$wmi_consumer_name$")="", "*", trim("$wmi_consumer_name$")), "*") 
+| eval input_wmi_consumer_destination = COALESCE(if(trim("$wmi_consumer_destination$")="", "*", trim("$wmi_consumer_destination$")), "*") 
+| eval input_user_name = COALESCE(if(trim("$user_name$")="", "*", trim("$user_name$")), "*") 
 
-    | fields - _raw _time count
-    | where reason!="CHANGEME"
-    | inputlookup append=t threathunting_wmi_whitelist.csv    
+| eval host_fqdn = input_host_fqdn 
+| eval mitre_technique_id = input_mitre_technique_id 
+| eval wmi_consumer_name = input_wmi_consumer_name 
+| eval wmi_consumer_destination = input_wmi_consumer_destination 
+| eval user_name = input_user_name 
+| eval reason = trim("$input_reason$") 
+| eval added_date = strftime(now(), "%Y-%m-%d") 
+| eval contact = ("$env:user$") 
+| table * 
+| fields - _raw _time count 
+| where reason!="CHANGEME" 
 
-| sort -added_date
-| dedup mitre_technique_id host_fqdn user_name wmi_consumer_name wmi_consumer_destination
-| outputlookup threathunting_wmi_whitelist.csv
-| fields added_date contact mitre_technique_id reason host_fqdn user_name wmi_consumer_name wmi_consumer_destination
+| inputlookup append=t threathunting_wmi_whitelist.csv 
+| sort -added_date 
+| dedup mitre_technique_id host_fqdn user_name wmi_consumer_name wmi_consumer_destination 
 
-          </query>
+| eval mode = "$input_mode$" 
+| eval delete=if(mode="delete" and mitre_technique_id=input_mitre_technique_id and host_fqdn=input_host_fqdn and wmi_consumer_name=input_wmi_consumer_name and wmi_consumer_destination=input_wmi_consumer_destination and user_name=input_user_name, "yes", "no") 
+| where delete="no" 
+| fields - delete mode 
+
+| outputlookup threathunting_wmi_whitelist.csv 
+| fields added_date contact mitre_technique_id reason host_fqdn user_name wmi_consumer_name wmi_consumer_destination</query>
           <earliest>0</earliest>
         </search>
         <option name="wrap">true</option>


### PR DESCRIPTION
Updated the following changes to the whitelist dashboards:
Registry - Add "add/remove" option for entries
Process create - Add "add/remove" option for entries
Network - Add "add/remove" option for entries, put sort before dedup like others
File access - Add "add/remove" option for entries, added contact like others
File create - Add "add/remove" option for entries, added contact like others, eval error with file_name pointed at file_path
Process access - Add "add/remove" option for entries
Remote threat - Add "add/remove" option for entries
Image load - Add "add/remove" option for entries
DNS - Add "add/remove" option for entries, added contact like others
Pipe created - Add "add/remove" option for entries
WMI -  Add "add/remove" option for entries