### PR TITLE
App Config Errors on Splunk Starting

### DIFF
--- a/default/macros.conf
+++ b/default/macros.conf
@@ -97,7 +97,8 @@ definition = | inputlookup threathunting_asset_priority.csv \
 iseval = 0
 
 [process_granted_access_description]
-eval process_granted_access_description=case(process_granted_access = "0x1fffff", "PROCESS_ALL_ACCESS",process_granted_access = "0x40", "PROCESS_DUP_HANDLE",process_granted_access = "0x40", "PROCESS_DUP_HANDLE(0x40) + PROCESS_VM_READ (0x0010)",process_granted_access = "0xc0", "PROCESS_DUP_HANDLE (0x40) + PROCESS_CREATE_PROCESS (0x80)",process_granted_access = "0x1010", "PROCESS_QUERY_LIMITED_INFORMATION (0x1000) + PROCESS_VM_READ (0x0010)", process_granted_access = "0x1410", "PROCESS_QUERY_LIMITED_INFORMATION (0x1000) + PROCESS_QUERY_INFORMATION (0x0400) + PROCESS_VM_READ (0x0010)",process_granted_access = "0x1001", "PROCESS_QUERY_LIMITED_INFORMATION (0x1000) + PROCESS_TERMINATE (0x0001)")
+definition = eval process_granted_access_description=case(process_granted_access = "0x1fffff", "PROCESS_ALL_ACCESS",process_granted_access = "0x40", "PROCESS_DUP_HANDLE",process_granted_access = "0x40", "PROCESS_DUP_HANDLE(0x40) + PROCESS_VM_READ (0x0010)",process_granted_access = "0xc0", "PROCESS_DUP_HANDLE (0x40) + PROCESS_CREATE_PROCESS (0x80)",process_granted_access = "0x1010", "PROCESS_QUERY_LIMITED_INFORMATION (0x1000) + PROCESS_VM_READ (0x0010)", process_granted_access = "0x1410", "PROCESS_QUERY_LIMITED_INFORMATION (0x1000) + PROCESS_QUERY_INFORMATION (0x0400) + PROCESS_VM_READ (0x0010)",process_granted_access = "0x1001", "PROCESS_QUERY_LIMITED_INFORMATION (0x1000) + PROCESS_TERMINATE (0x0001)")
+iseval = 0
 
 [threathunting_index]
 definition = index=threathunting

--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -382,9 +382,9 @@ dispatch.latest_time = now
 enableSched = 1
 schedule_window = auto
 search = `indextime` `windows-security` event_id=4688 (".Download" OR "Net.WebClient") \
-| eval hunting_trigger="Download or web connection"
-| eval mitre_category="Execution"
-| eval mitre_technique="PowerShell"
+| eval hunting_trigger="Download or web connection" \
+| eval mitre_category="Execution" \
+| eval mitre_technique="PowerShell" \
 | eval mitre_technique_id="T1086" \
 | eval hash_sha256= lower(hash_sha256)\
 | `process_create_whitelist`\
@@ -1101,7 +1101,7 @@ dispatch.latest_time = now
 enableSched = 1
 schedule_window = auto
 search = `indextime` `sysmon` event_id=20 wmi_consumer_type="Command Line" \
-| eval hunting_trigger="WMI command execution
+| eval hunting_trigger="WMI command execution \
 | eval mitre_category="Lateral_Movement"\
 | eval mitre_technique="Windows_Management_Instrumentation"\
 | eval mitre_technique_id = "T1047" \
@@ -2790,7 +2790,7 @@ schedule_window = auto
 search = `indextime` `sysmon` event_id=22 [| inptlookup doh.csv] \
 | eval mitre_category="Command_and_Control"\
 | eval mitre_technique="Standard Application Layer Protocol"\
-| eval hunting_trigger="DNS over HTTPS used
+| eval hunting_trigger="DNS over HTTPS used" \
 | eval mitre_technique_id="T1071" \
 | eval event_description="DNS Query"  | `dns_whitelist` | table _time indextime event_description host_fqdn process_path query_name query_status query_results process_guid mitre_category mitre_technique mitre_technique_id hunting_trigger\
 | collect `threathunting_index`


### PR DESCRIPTION
fixed missing characters and formatting causing configuration errors when when was started. 

These types of errors can be found running splunk btool check --debug.

