### PR TITLE
Update savedsearches.conf

### DIFF
--- a/default/savedsearches.conf
+++ b/default/savedsearches.conf
@@ -994,7 +994,7 @@ enableSched = 1
 schedule_window = auto
 request.ui_dispatch_app = ThreatHunting
 request.ui_dispatch_view = search
-search = `indextime` `sysmon` (event_id=12 OR event_id=13 OR event_id=14) process_path!="C:\\WINDOWS\\system32\\lsass.exe"  (registry_key_path="*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SecurityProviders\\*" OR registry_key_path="*\\Control\\SecurityProviders\\WDigest\\*") NOT registry_key_path="*\\Lsa\\RestrictRemoteSamEventThrottlingWindow NOT registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\nolmhash" \
+search = `indextime` `sysmon` (event_id=12 OR event_id=13 OR event_id=14) process_path!="C:\\WINDOWS\\system32\\lsass.exe"  (registry_key_path="*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Authentication\\Credential Provider\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\*" OR registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\SecurityProviders\\*" OR registry_key_path="*\\Control\\SecurityProviders\\WDigest\\*") NOT registry_key_path="*\\Lsa\\RestrictRemoteSamEventThrottlingWindow" NOT registry_key_path="*\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\nolmhash" \
 | eval mitre_category="Credential_Access"\
 | eval mitre_technique="Credential Dumping"\
 | eval mitre_technique_id="T1003" \
@@ -1101,7 +1101,7 @@ dispatch.latest_time = now
 enableSched = 1
 schedule_window = auto
 search = `indextime` `sysmon` event_id=20 wmi_consumer_type="Command Line" \
-| eval hunting_trigger="WMI command execution \
+| eval hunting_trigger="WMI command execution" \
 | eval mitre_category="Lateral_Movement"\
 | eval mitre_technique="Windows_Management_Instrumentation"\
 | eval mitre_technique_id = "T1047" \


### PR DESCRIPTION
Unbalanced quotes causing [T1003] Credential Dumping - Registry and [T1047] WMI command execution searches to fail.